### PR TITLE
Correctness fixes and (optional) better C stdlib integration

### DIFF
--- a/tinyalloc.c
+++ b/tinyalloc.c
@@ -134,6 +134,9 @@ bool ta_init(const void *base, const void *limit, const size_t heap_blocks, cons
 }
 
 bool ta_free(void *free) {
+    if (free == NULL) {
+        return false;
+    }
     Block *block = heap->used;
     Block *prev  = NULL;
     while (block != NULL) {

--- a/tinyalloc.h
+++ b/tinyalloc.h
@@ -8,6 +8,8 @@ extern "C" {
 bool ta_init(const void *base, const void *limit, const size_t heap_blocks, const size_t split_thresh, const size_t alignment);
 void *ta_alloc(size_t num);
 void *ta_calloc(size_t num, size_t size);
+size_t ta_getsize(void *ptr);
+void *ta_realloc(void *ptr, size_t num);
 bool ta_free(void *ptr);
 
 size_t ta_num_free();


### PR DESCRIPTION
- Add early NULL check to ta_free()
- Add overflow checks in alloc_block() and ta_calloc()
- Clear full block size to 0's in ta_calloc()
- Optionally set errno to ENOMEM when out of memory
- Optionally use memset() to implement memclear()
- Add ta_getsize() to return allocated block size
- Add ta_realloc() (optional, requires memcpy())

ta_getsize() and ta_realloc() are based on ideas from #11, but rewritten to fix various issues in that PR.